### PR TITLE
Fix HandleRight and prevent player from immediately reversing

### DIFF
--- a/game.go
+++ b/game.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/dustinkirkland/golang-petname"
-	"github.com/fatih/color"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"math/rand"
 	"sort"
 	"time"
+
+	"github.com/dustinkirkland/golang-petname"
+	"github.com/fatih/color"
+	"golang.org/x/crypto/ssh"
 )
 
 type Hub struct {
@@ -197,6 +198,7 @@ func (p *Player) HandleDown() {
 func (p *Player) HandleRight() {
 	p.Direction = PlayerRight
 	p.Marker = playerRightRune
+	p.s.didAction()
 }
 
 func (p *Player) Score() int {

--- a/game.go
+++ b/game.go
@@ -178,24 +178,36 @@ func (p *Player) calculateScore(delta float64, playerCount int) float64 {
 }
 
 func (p *Player) HandleUp() {
+	if p.Direction == PlayerDown {
+		return
+	}
 	p.Direction = PlayerUp
 	p.Marker = playerUpRune
 	p.s.didAction()
 }
 
 func (p *Player) HandleLeft() {
+	if p.Direction == PlayerRight {
+		return
+	}
 	p.Direction = PlayerLeft
 	p.Marker = playerLeftRune
 	p.s.didAction()
 }
 
 func (p *Player) HandleDown() {
+	if p.Direction == PlayerUp {
+		return
+	}
 	p.Direction = PlayerDown
 	p.Marker = playerDownRune
 	p.s.didAction()
 }
 
 func (p *Player) HandleRight() {
+	if p.Direction == PlayerLeft {
+		return
+	}
 	p.Direction = PlayerRight
 	p.Marker = playerRightRune
 	p.s.didAction()


### PR DESCRIPTION
I've been letting my 4 year old and 6 year old play this. We ran across a bug and we also thought of some functionality to add. 

```fix: HandleRight() not updating LastAction, edge case player is kicked```
```enhc: prevent player from immediately reversing into their own trail```

