### PR TITLE
Add wrapper script and snapcraft.yaml for packaging as a snap.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+---
+name: sshtron
+version: 1.0
+summary: Multiplayer Tron via SSH
+description: >
+    Multiplayer Tron game, accessible via SSH.
+    Once it's installed, ssh to port 2022, and steer using the W A S D keys.
+confinement: strict
+apps:
+    sshtron:
+        command: bin/sshtron-server
+        daemon: simple
+        plugs: [network-bind]
+
+parts:
+    sshtron:
+        plugin: go
+        source: git://github.com/zachlatta/sshtron
+    glue:
+        plugin: copy
+        files:
+            sshtron.sh: bin/sshtron-server
+        stage-packages:
+            - openssh-client

--- a/sshtron.sh
+++ b/sshtron.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd "$SNAP_DATA"
+
+[ -f id_rsa ] || $SNAP/usr/bin/ssh-keygen -t rsa -N '' -f id_rsa
+
+sshtron > "$SNAP_DATA/sshtron.log" 2>&1


### PR DESCRIPTION
This requires snapcraft to build the snap package, which
can then be installed on Ubuntu or any Linux distro with
snapd installed.