### PR TITLE
Clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
 FROM golang:latest
 
-ENV PROJECT_NAME sshtron
-ENV PROJECT_PATH github.com/zachlatta/sshtron
-
-ADD . $GOPATH/src/$PROJECT_PATH
-WORKDIR $GOPATH/src/$PROJECT_PATH
+WORKDIR $GOPATH/src/github.com/zachlatta/sshtron
 
 RUN apt-get update && apt-get install openssh-client && \
-	ssh-keygen -t rsa -N "" -f id_rsa && \
-	go get && go install && \
-	rm -rf /var/lib/apt/lists/*
+	ssh-keygen -t rsa -N "" -f id_rsa
+
+ADD . .
+RUN go get && go install
 
 ENTRYPOINT sshtron
-


### PR DESCRIPTION
- Removed unnecessary `ENV` to save up two layers.
- Moved `ADD` to bottom and split SSH installation and `go install`, to take advantage of intermediate layer caching. No more `apt-get install` after every build. :tada: 
- Removed `rm -rf /var/lib/apt/lists/*` as `jessie` images automatically cleans up after `apt-get install` as discussed [here](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run):
   > **Note:** The official Debian and Ubuntu images [automatically run `apt-get clean`](https://github.com/docker/docker/blob/03e2923e42446dbb830c654d0eec323a0b4ef02a/contrib/mkimage/debootstrap#L82-L105), so explicit invocation is not required.