### PR TITLE
Add ability to choose color

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ _Controls: WASD or vim keybindings to move (**do not use your arrow keys**). Esc
 
 **Code quality disclaimer:** _SSHTron was built in ~20 hours at [BrickHack 2](https://brickhack.io/). Here be dragons._
 
+## Want to choose color yourself?
+
+There are total 7 colors to choose from: Red, Green, Yellow, Blue, Magenta, Cyan and White
+
+    $ ssh red@sshtron.zachlatta.com
+
 ## Running Your Own Copy
 
 Clone the project and `cd` into its directory. These instructions assume that you have your `GOPATH` setup correctly.

--- a/game.go
+++ b/game.go
@@ -95,8 +95,11 @@ const (
 
 	playerRed     = color.FgRed
 	playerGreen   = color.FgGreen
+	playerYellow  = color.FgYellow
+	playerBlue    = color.FgBlue
 	playerMagenta = color.FgMagenta
 	playerCyan    = color.FgCyan
+	playerWhite   = color.FgWhite
 
 	PlayerUp PlayerDirection = iota
 	PlayerLeft
@@ -104,21 +107,29 @@ const (
 	PlayerRight
 )
 
-var playerColors = []color.Attribute{playerRed, playerGreen, playerMagenta,
-	playerCyan}
+var playerColors = []color.Attribute{
+	playerRed, playerGreen, playerYellow, playerBlue,
+	playerMagenta, playerCyan, playerWhite,
+}
 
 var playerBorderColors = map[color.Attribute]color.Attribute{
 	playerRed:     color.FgHiRed,
 	playerGreen:   color.FgHiGreen,
+	playerYellow:  color.FgHiYellow,
+	playerBlue:    color.FgHiBlue,
 	playerMagenta: color.FgHiMagenta,
 	playerCyan:    color.FgHiCyan,
+	playerWhite:   color.FgHiWhite,
 }
 
 var playerColorNames = map[color.Attribute]string{
 	playerRed:     "Red",
 	playerGreen:   "Green",
+	playerYellow:  "Yellow",
+	playerBlue:    "Blue",
 	playerMagenta: "Magenta",
 	playerCyan:    "Cyan",
+	playerWhite:   "White",
 }
 
 type PlayerTrailSegment struct {
@@ -129,6 +140,7 @@ type PlayerTrailSegment struct {
 type Player struct {
 	s *Session
 
+	Name	  string
 	CreatedAt time.Time
 	Direction PlayerDirection
 	Marker    rune

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ const (
 func handler(conn net.Conn, gm *GameManager, config *ssh.ServerConfig) {
 	// Before use, a handshake must be performed on the incoming
 	// net.Conn.
-	_, chans, reqs, err := ssh.NewServerConn(conn, config)
+	sshConn, chans, reqs, err := ssh.NewServerConn(conn, config)
 	if err != nil {
 		fmt.Println("Failed to handshake with new client")
 		return
@@ -66,7 +66,7 @@ func handler(conn net.Conn, gm *GameManager, config *ssh.ServerConfig) {
 			}
 		}(requests)
 
-		gm.HandleChannel <- channel
+		gm.HandleNewChannel(channel, sshConn.User())
 	}
 }
 
@@ -102,7 +102,6 @@ func main() {
 
 	// Create the GameManager
 	gm := NewGameManager()
-	go gm.Run()
 
 	fmt.Printf(
 		"Listening on port %s for SSH and port %s for HTTP...\n",


### PR DESCRIPTION
Zach, we play SSH Tron at our office a lot during our free time :stuck_out_tongue: The problem was, four colors weren't enough, so I added more ANSI colors supported by `fatih/color`.

We like to play Tron in teams, 3 players on each team. The goal of each team is to make the highest score collectively. So the strategy is to kill the opponents and defend your highest scorer.
So if you remember your team members' color, it gets easy. So I added the feature to let the user choose their own color.

```sh
$ ssh [color]@server -p 2022
```

Kudos for a great game! :+1: 