### PR TITLE
 Add win streak rainbows to the trails. 

### DIFF
--- a/game.go
+++ b/game.go
@@ -625,7 +625,7 @@ func (g *Game) worldString(s *Session) string {
 		pos := player.Pos
 		strWorld[pos.RoundX()+1][pos.RoundY()+1] = colorizer(string(player.Marker))
 
-        // Make the rainbow of trail colors to cycle over
+                // Make the rainbow of trail colors to cycle over
 		trailColorizers := make([](func(...interface{}) string), len(player.WinStreak)+1)
 		trailColorizers[0] = colorizer
 		for i, winColor := range player.WinStreak {


### PR DESCRIPTION
Whenever a player collides with another player's
trail, the surviving player gets the dead player's
color added to their trail rainbow, indicating their
win streak.

When a player dies, their streak ends and their trail
starts back again as a solid color.

Issue #24 